### PR TITLE
Update to use conda and modify conda channels and channel priority in install-dependencies action.yml

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -24,9 +24,8 @@ runs:
       uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: 3.11
-        mamba-version: "*"
-        channels: conda-forge,bioconda,defaults
-        channel-priority: true
+        channels: conda-forge,bioconda
+        channel-priority: strict
         activate-environment: anaconda-client-env
     - name: Setup nextflow
       uses: nf-core/setup-nextflow@v2


### PR DESCRIPTION
Currently, the mamba setup via [setup-miniconda](https://github.com/conda-incubator/setup-miniconda) is broken (https://github.com/conda-incubator/setup-miniconda/actions/runs/11062487757). So we're temporarily moving to use conda.