### PR TITLE
Update output path checks in GitHub Actions workflow for metadata files

### DIFF
--- a/.github/workflows/process_sra_hosted.yml
+++ b/.github/workflows/process_sra_hosted.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run nextflow
         run: nextflow run https://github.com/gp201/flusra.git -r ${{ env.FLUSRA_VERSION }} -c ${{ github.workspace }}/config/nextflow.config -profile mamba --bioproject ${{ env.BIOPROJECTS }} --outdir ${{ env.NXF_OUTPUT }} -name ${{ env.NXF_NAME }} -with-tower -latest
       - name: Push outputs
-        if: ${{ hashFiles('${{ env.NXF_OUTPUT }}/metadata/') != '' }}
+        if: ${{ hashFiles('outputs/metadata/*.tsv') != '' }}
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
@@ -64,8 +64,7 @@ jobs:
         if: ${{ github.event.inputs.testing != 'true' || github.event_name == 'schedule' }}
         run: git push
       - name: Generate Run Summary
-        working-directory: ${{ env.NXF_OUTPUT }}
-        if: ${{ hashFiles('${{ env.NXF_OUTPUT }}/metadata/') != '' }}
+        if: ${{ hashFiles('outputs/metadata/*.tsv') != '' }}
         run: |
           echo "# Job Summary $(date)" >> $GITHUB_STEP_SUMMARY
           echo "## Job Information" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/process_sra_hosted.yml` file to update the conditions for pushing outputs and generating run summaries. The changes ensure that the workflow checks for the presence of specific metadata files in the `outputs/metadata` directory instead of using the `NXF_OUTPUT` environment variable.

Updates to workflow conditions:

* [`.github/workflows/process_sra_hosted.yml`](diffhunk://#diff-837d1cb85146d1ae7b898b2d30b3467a55e29f76a7c28742df6e0925aeb75180L46-R46): Updated the condition for the "Push outputs" step to check for the presence of `.tsv` files in the `outputs/metadata` directory.
* [`.github/workflows/process_sra_hosted.yml`](diffhunk://#diff-837d1cb85146d1ae7b898b2d30b3467a55e29f76a7c28742df6e0925aeb75180L67-R67): Updated the condition for the "Generate Run Summary" step to check for the presence of `.tsv` files in the `outputs/metadata` directory.