### PR TITLE
Update cron schedule for GenBank mapping and SRA processing workflows

### DIFF
--- a/.github/workflows/map_to_genbank_seqs.yml
+++ b/.github/workflows/map_to_genbank_seqs.yml
@@ -2,7 +2,7 @@ name: Map to GenBank Sequences
 run-name: ${{ github.event.inputs.reason || 'Scheduled Run' }}
 on:
   schedule:
-    - cron: '15 1 * * *'
+    - cron: '15 13 * * *'
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/process_sra_hosted.yml
+++ b/.github/workflows/process_sra_hosted.yml
@@ -2,7 +2,7 @@ name: Process Flu SRA (self-hosted)
 run-name: ${{ github.event.inputs.reason || 'Scheduled Run' }}
 on:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 13 * * *'
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
This pull request includes changes to the scheduling times in two GitHub Actions workflows. The most important changes are:

* [`.github/workflows/map_to_genbank_seqs.yml`](diffhunk://#diff-965236539dbec3ca3d7a3327f8fe0b61e1e5fe052d05d938be942eab07f4b320L5-R5): Updated the cron schedule from `1:15 AM` to `1:15 PM`.
* [`.github/workflows/process_sra_hosted.yml`](diffhunk://#diff-837d1cb85146d1ae7b898b2d30b3467a55e29f76a7c28742df6e0925aeb75180L5-R5): Updated the cron schedule from `1:00 AM` to `1:00 PM`.