### PR TITLE
Rename "Push outputs" step to "Commit outputs" in GitHub Actions workflow and add conditional check for metadata files

### DIFF
--- a/.github/workflows/process_sra_hosted.yml
+++ b/.github/workflows/process_sra_hosted.yml
@@ -42,7 +42,8 @@ jobs:
       - uses: ./.github/actions/install-dependencies
       - name: Run nextflow
         run: nextflow run https://github.com/gp201/flusra.git -r ${{ env.FLUSRA_VERSION }} -c ${{ github.workspace }}/config/nextflow.config -profile mamba --bioproject ${{ env.BIOPROJECTS }} --outdir ${{ env.NXF_OUTPUT }} -name ${{ env.NXF_NAME }} -with-tower -latest
-      - name: Push outputs
+      - name: Commit outputs
+        if: ${{ hashFiles('outputs/metadata/*.csv') != '' }}
         run: |
           # Configure Git
           git config --global user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/process_sra_hosted.yml` file. The change modifies the step where outputs are handled to ensure that only when there are changes in the `outputs/metadata` directory, the outputs will be committed.

* [`.github/workflows/process_sra_hosted.yml`](diffhunk://#diff-837d1cb85146d1ae7b898b2d30b3467a55e29f76a7c28742df6e0925aeb75180L45-R46): Changed the step name from "Push outputs" to "Commit outputs" and added a condition to check for changes in `outputs/metadata/*.csv` before committing.