### PR TITLE
Refactor file moving logic in GitHub Actions workflow to use find command for improved efficiency

### DIFF
--- a/.github/workflows/process_sra_hosted.yml
+++ b/.github/workflows/process_sra_hosted.yml
@@ -55,14 +55,14 @@ jobs:
           # Process fasta, depth, and variants directories in a loop
           for dir in fasta depth variants; do
             if [ -d "${{ env.NXF_OUTPUT }}/$dir/" ]; then
-              mv "${{ env.NXF_OUTPUT }}/$dir/"* "${{ github.workspace }}/$dir/"
+              find "${{ env.NXF_OUTPUT }}/$dir/" -maxdepth 1 -type f -exec mv {} "${{ github.workspace }}/$dir/" \;
               git add "${{ github.workspace }}/$dir/"
             fi
           done
 
           # Process demixed directory
           if [ -d "${{ env.NXF_OUTPUT }}/demixed/" ]; then
-            mv "${{ env.NXF_OUTPUT }}/demixed/"* "${{ github.workspace }}/demixed/"
+            find "${{ env.NXF_OUTPUT }}/demixed/" -maxdepth 1 -type f -exec mv {} "${{ github.workspace }}/demixed/" \;
             git add "${{ github.workspace }}/demixed/"
           fi
 


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/process_sra_hosted.yml` file to improve the handling of directories during the processing of fasta, depth, variants, and demixed files. The most important changes are:

* Modified the loop processing `fasta`, `depth`, and `variants` directories to use `find` with `-maxdepth 1 -type f` to move files, avoid `/usr/bin/mv: Argument list too long` error (.github/workflows/process_sra_hosted.yml)
* Updated the processing of the `demixed` directory to use `find` with `-maxdepth 1 -type f` to move files, and avoid `/usr/bin/mv: Argument list too long` error (.github/workflows/process_sra_hosted.yml)