### PR TITLE
Refactor conditional logic for GitHub Actions workflow to simplify push criteria

### DIFF
--- a/.github/workflows/process_sra_hosted.yml
+++ b/.github/workflows/process_sra_hosted.yml
@@ -70,7 +70,7 @@ jobs:
           git add "${{ github.workspace }}/metadata/SraRunTable_automated.csv"
           git commit -m "Add consensus sequences, depth, variant files, demixed files and updated metadata"
       - name: Push to GitHub
-        if: ${{ (github.event.inputs.testing != 'true' || github.event_name == 'schedule') && hashFiles('outputs/metadata/*.csv') != '' }}
+        if: ${{ github.event.inputs.testing != 'true' || github.event_name == 'schedule' }}
         run: git push
       - name: Generate Run Summary
         if: ${{ hashFiles('outputs/metadata/*.tsv') != '' }}


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/process_sra_hosted.yml` file. The change simplifies the condition for the "Push to GitHub" step by removing the check for non-empty CSV files in the `outputs/metadata` directory.

* [`.github/workflows/process_sra_hosted.yml`](diffhunk://#diff-837d1cb85146d1ae7b898b2d30b3467a55e29f76a7c28742df6e0925aeb75180L73-R73): Simplified the condition for the "Push to GitHub" step by removing the check for non-empty CSV files.