### PR TITLE
Add excluded samples metadata

### DIFF
--- a/metadata/excluded_samples.csv
+++ b/metadata/excluded_samples.csv
@@ -1,0 +1,3 @@
+Run,Reason
+SRR31959977,"This sample is identified as a H5N9 subtype by the NCBI Influenza Virus Sequence Annotation Tool https://www.ncbi.nlm.nih.gov/datasets/genome/GCA_047940555.1/"
+SRR31959978,"This sample is identified as a H5N9 subtype by the NCBI Influenza Virus Sequence Annotation Tool https://www.ncbi.nlm.nih.gov/datasets/genome/GCA_047940145.1/"


### PR DESCRIPTION
This pull request includes an update to the `metadata/excluded_samples.csv` file. The update adds new entries for samples that are to be excluded from the repository.

Changes to excluded samples:

* [`metadata/excluded_samples.csv`](diffhunk://#diff-47d02916778521c85f0747c726537f7c9e85e95cf1c89947e78d44e6316c4d7bR1-R3): Added two new samples (`SRR31959977` and `SRR31959978`) with their respective reasons for exclusion.