### PR TITLE
chore: update NXF_VER to 24.10.5 in workflow configuration

### DIFF
--- a/.github/workflows/process_sra_hosted.yml
+++ b/.github/workflows/process_sra_hosted.yml
@@ -17,7 +17,7 @@ concurrency:
   group: ${{ github.repository }}
 
 env:
-  NXF_VER: "24.10.4"
+  NXF_VER: "24.10.5"
   NXF_WORK: ${{ github.workspace }}/work
   NXF_OUTPUT: ${{ github.workspace }}/outputs
   NXF_NAME: github-${{ github.run_number }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/process_sra_hosted.yml` file. The change updates the `NXF_VER` environment variable to a new version.

* [`.github/workflows/process_sra_hosted.yml`](diffhunk://#diff-837d1cb85146d1ae7b898b2d30b3467a55e29f76a7c28742df6e0925aeb75180L20-R20): Updated `NXF_VER` from "24.10.4" to "24.10.5".