### PR TITLE
ci: Migrate CI to new server

### DIFF
--- a/.github/workflows/process_sra_hosted.yml
+++ b/.github/workflows/process_sra_hosted.yml
@@ -32,7 +32,7 @@ defaults:
 
 jobs:
   process_sra:
-    runs-on: self-hosted
+    runs-on: [self-hosted, profchaos]
     permissions:
         contents: write
         id-token: write


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for the `process_sra` job to enhance its flexibility and compatibility.

Workflow configuration updates:

* [`.github/workflows/process_sra_hosted.yml`](diffhunk://#diff-837d1cb85146d1ae7b898b2d30b3467a55e29f76a7c28742df6e0925aeb75180L35-R35): Modified the `runs-on` parameter for the `process_sra` job to run the action on the new server.