### PR TITLE
fix: remove caching from GitHub Actions workflow as we don't specify a requirements file

### DIFF
--- a/.github/workflows/map_to_genbank_seqs.yml
+++ b/.github/workflows/map_to_genbank_seqs.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install pandas==2.3.1 biopython==1.85 polars==1.31.0 Unidecode==1.4.0 requests==2.32.4 pyarrow==21.0.0


### PR DESCRIPTION
This pull request modifies the GitHub Actions workflow file `.github/workflows/map_to_genbank_seqs.yml` to remove the use of the `pip` cache during the setup of Python dependencies.

Key change:

* Removed the `cache: 'pip'` configuration from the `setup-python` action, which disables caching for Python dependencies.