### PR TITLE
feat: Normalize isolation source and host fields to lowercase in metadata processing

### DIFF
--- a/scripts/metadata_normalizer.py
+++ b/scripts/metadata_normalizer.py
@@ -387,7 +387,8 @@ def normalize_metadata(metadata_df: pl.DataFrame) -> pl.DataFrame:
                 pl.col("Collection_Date").map_elements(normalize_date, return_dtype=pl.String),
                 pl.col("geo_loc_name").cast(pl.String).str.strip_chars().map_elements(normalize_location, return_dtype=pl.String),
                 pl.col("Run").cast(pl.String).str.strip_chars().alias("Run"),
-                pl.col("isolation_source").cast(pl.String).str.strip_chars().alias("isolation_source")
+                pl.col("isolation_source").cast(pl.String).str.strip_chars().str.to_lowercase().alias("isolation_source"),
+                pl.col("Host").cast(pl.String).str.strip_chars().str.to_lowercase().alias("Host"),
             ))
 
 


### PR DESCRIPTION
This pull request updates the metadata normalization logic in `scripts/metadata_normalizer.py` to improve consistency in string formatting for `isolation_source` and `Host` columns. The most important changes are grouped below:

**Data normalization improvements:**

* The `isolation_source` column is now converted to lowercase after stripping characters.
* A new normalization step for the `Host` column has been added: it is cast to string, stripped of extraneous characters, and converted to lowercase for consistency.